### PR TITLE
Improve the gem's description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Readline Loader
 
-This is just loader for "readline". If Ruby has "readline-ext" gem that is a native extension, this gem will load its first. If Ruby doesn't have the "readline-ext" gem this gem will load "reline" that is a compatible library with "readline-ext" gem and is implemented by pure Ruby.
+This is just a loader for "readline". If Ruby has the "readline-ext" gem
+that is a native extension, this gem will load it. If Ruby does not have
+the "readline-ext" gem this gem will load "reline", a library that is
+compatible with the "readline-ext" gem and implemented in pure Ruby.
 
 ## License
 

--- a/readline.gemspec
+++ b/readline.gemspec
@@ -4,12 +4,12 @@ Gem::Specification.new do |spec|
   spec.authors       = ['aycabta']
   spec.email         = ['aycabta@gmail.com']
 
-  spec.summary       = %q{It's a loader for "readline".}
+  spec.summary       = %q{Loader for "readline".}
   spec.description   = <<~EOD
-    This is just a loader for "readline". If Ruby has "readline-ext" gem that
-    is a native extension, this gem will load it first. If Ruby doesn't have
-    the "readline-ext" gem this gem will load "reline" that is a compatible
-    library with "readline-ext" gem and is implemented by pure Ruby.
+    This is just a loader for "readline". If Ruby has the "readline-ext" gem
+    that is a native extension, this gem will load it. If Ruby does not have
+    the "readline-ext" gem this gem will load "reline", a library that is
+    compatible with the "readline-ext" gem and implemented in pure Ruby.
   EOD
   spec.homepage      = 'https://github.com/ruby/readline'
   spec.license       = 'Ruby license'
@@ -19,13 +19,13 @@ Gem::Specification.new do |spec|
 
   spec.post_install_message = <<~EOM
     +---------------------------------------------------------------------------+
-    | This is just a loader for "readline". If Ruby has "readline-ext" gem that |
-    | is a native extension, this gem will load it first. If Ruby doesn't have  |
-    | the "readline-ext" gem this gem will load "reline" that is a compatible   |
-    | library with "readline-ext" gem and is implemented by pure Ruby.          |
-    |                                                                           |
+    | This is just a loader for "readline". If Ruby has the "readline-ext" gem  |
+    | that is a native extension, this gem will load it. If Ruby does not have  |
+    | the "readline-ext" gem this gem will load "reline", a library that is     |
+    | compatible with the "readline-ext" gem and implemented in pure Ruby.      |
+    |                                                                           |
     | If you intend to use GNU Readline by `require 'readline'`, please install |
-    | "readline-ext" gem.                                                       |
+    | the "readline-ext" gem.                                                   |
     +---------------------------------------------------------------------------+
   EOM
 


### PR DESCRIPTION
Improve the language in the gem's summary and description;
also remove U+00A0 (no-break space) characters from post-install box.