### PR TITLE
Gemfile: remove unused github alias

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,3 @@
 source 'https://rubygems.org'
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
-
-# Specify your gem's dependencies in readline.gemspec
 gemspec


### PR DESCRIPTION
This git_source is now the default one for "github" in Bundler 2, and we are not using it, so we can simplify it away.