### PR TITLE
Suppress constant redefinition warning

### DIFF
--- a/lib/readline.rb
+++ b/lib/readline.rb
@@ -2,5 +2,6 @@ begin
   require 'readline.so'
 rescue LoadError
   require 'reline' unless defined? Reline
+  Object.send(:remove_const, :Readline) if Object.const_defined?(:Readline)
   Readline = Reline
 end


### PR DESCRIPTION
When already set by `use_lib_reline` in test/readline/helper.rb of readline-ext.