### PR TITLE
Fix readline-ext gem loading in non Unix-like environments

### DIFF
--- a/lib/readline.rb
+++ b/lib/readline.rb
@@ -1,5 +1,5 @@
 begin
-  require 'readline.so'
+  require "readline.#{RbConfig::CONFIG["DLEXT"]}"
 rescue LoadError
   require 'reline' unless defined? Reline
   Object.send(:remove_const, :Readline) if Object.const_defined?(:Readline)


### PR DESCRIPTION
I would like to suggest a fix because readline-ext loading is not working properly in non-Unix-like environments.

## Why

The call `require "foo.so"` first calls the `require` overridden by RubyGems, which in turn calls ruby's native `require`.
When ruby's native `require` loads "foo.so", it searches for the appropriate file for each environment, such as foo.so, foo.bundle, or foo.dll.
However, RubyGems's `require` tries to load "foo.so" and does not look for files like foo.bundle, foo.dll.

So I have created this PR. With this change, the `require "readline"` call will load the native extension of the readline-ext gem.


## Behavior of existing implementation.
### Environment with .so extension (e.g. Linux)
Existing implementations and this PR implementation work fine.

The call "readline.so" and the actual file name match.


### Environment with bundler
If you run via Bundler in a Gemfile like the following, ruby add the path of the gem to LOAD_PATH, so even ruby native require can find the readline.{bundle,dll,...} and load it successfully.

```ruby
source "https://rubygems.org"

gem "readline-ext"
```

### Environment where the extention extension is not .so (e.g. macOS) with Ruby <= 3.2
Until Ruby 3.2, ext/readline was a standard library, so when you do `require "readline.so"', RubyGems's require cannot find readline.so and native require can find the readline extension (e.g. readline.bundle) of ext/readline.
On the other hand, the readline extension of readline-ext is not used.

### Environment where the extention extension is not .so (e.g. macOS) with Ruby 3.3
In Ruby 3.3, since ext/readline is retired, it will not find the readline native extension provided by the readline-ext gem and will fall back to loading relines.
